### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_ting_frontend.make
+++ b/ding_ting_frontend.make
@@ -5,7 +5,7 @@ api = 2
 
 ; Projects
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[i18n][subdir] = "contrib"
 projects[i18n][version] = "1.8"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.